### PR TITLE
Add info about validators as modules to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ An extendible validation framework for validating the properties of an object. A
 
       make tests
 
+## Validators
+
+Validity comes with some very basic example validators (required, email, integer, length and a few others). No more validators
+will be added to this repo (in fact some of the more obscure ones may be removed in future). They should be built as individual
+npm modules (with their own tests) so that applications can pick and choose which they use. Validators should be added to npm
+repo with the `validity-` prefix so that people can find them with a quick [npm search](https://npmjs.org/search?q=validity-)
+(or via the cli: `npm search validity-`).
+
+The are a few validators that currently exist and can be used for reference:
+
+- [validity-date-before-property](https://npmjs.org/package/validity-date-before-property)
+- [validity-number-in-range](https://npmjs.org/package/validity-number-in-range)
+
 ## Credits
 [Paul Serby](https://github.com/serby/) follow me on twitter [@serby](http://twitter.com/serby)
 


### PR DESCRIPTION
I added this to help create a little eco-system around validators in the npm regisrtry, in order to:
1. help people discover validators they might need
2. encourage people to write standalone validators that are useful to others and publish them
